### PR TITLE
Feat: Agrega Docker, MySQL y documentación

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ build/
 mvnw
 mvnw.cmd
 
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# --- ETAPA 1: CONSTRUCCIÓN (BUILD) ---
+# Usamos una imagen que ya trae Maven instalado oficial
+FROM maven:3.9.6-eclipse-temurin-17 AS builder
+
+WORKDIR /app
+
+# Copiamos solo el pom.xml para descargar librerías (aprovecha el caché de Docker)
+COPY pom.xml .
+
+# Descargamos las dependencias usando el Maven de la imagen
+RUN mvn dependency:go-offline
+
+# Copiamos el código fuente
+COPY src ./src
+
+# Compilamos el proyecto y generamos el .jar
+RUN mvn clean package -DskipTests
+
+# --- ETAPA 2: EJECUCIÓN (RUN) ---
+# Usamos una imagen limpia y liviana solo con Java para correr la app
+FROM eclipse-temurin:17-jdk-jammy
+
+WORKDIR /app
+
+# Copiamos el .jar generado en la Etapa 1 a esta nueva etapa
+# El *.jar busca cualquier archivo que termine en .jar en la carpeta target
+COPY --from=builder /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+# Ejecutamos el archivo que renombramos como app.jar
+CMD ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -59,3 +59,39 @@ curl -X POST http://localhost:8080/api/lp3/persona/ \
 curl -s http://localhost:8080/api/lp3/persona/ | jq
 # (Se recomienda tener instalado jq para visualizar mejor la respuesta JSON: sudo apt install jq)
 ```
+
+## Ejecución con Docker Compose
+
+Este proyecto incluye configuración para ejecutarse en contenedores Docker, orquestando la aplicación y la base de datos automáticamente.
+
+### Requisitos
+
+* Docker y Docker Compose instalados.
+
+### Paso a Paso
+
+1. **Configurar credenciales:**
+Crear un archivo ```.env``` en la raíz del proyecto tomando como base el ejemplo:
+```bash
+cp env.sample .env
+```
+
+(El archivo .env ya está configurado con credenciales por defecto funcionales).
+
+2. **Iniciar la aplicación:**
+Ejecutar el siguiente comando para construir y levantar los servicios:
+```bash
+docker compose up --build
+```
+
+3. **Acceso:**
+
+* **API Spring Boot:** Disponible en ```http://localhost:8081/api/lp3/persona/``` (Note el puerto 8081).
+
+* **Base de Datos:** Accesible desde el host en el puerto **3307.**
+
+4. **Detener:**
+Para apagar los contenedores:
+```bash
+docker compose down
+```

--- a/README.md
+++ b/README.md
@@ -1,97 +1,49 @@
-# Trabajo Práctico LP3 - Spring Boot con MySQL
+# Trabajo Práctico LP3 - Spring Boot con Docker
 
-Este proyecto es una adaptación del template de LP3 para utilizar persistencia de datos en **MySQL**.
+Este proyecto es una aplicación Spring Boot con base de datos MySQL, orquestada completamente con Docker Compose.
 
-> **Nota:** Se ha migrado la base de datos original (H2) a MySQL Server 8.
+> **Nota:** Gracias a Docker, no es necesario instalar Java ni MySQL localmente.
 
 ## Requisitos Previos
 
-* **Java JDK 17** o superior.
-* **MySQL Server 8.0** instalado y corriendo.
-* **Maven** (incluido en el wrapper `./mvnw`).
+* **Docker** y **Docker Compose** instalados y corriendo.
 
-## Configuración de Base de Datos
+## Configuración Inicial
 
-Antes de ejecutar la aplicación, es necesario crear la base de datos y el usuario en MySQL para que la conexión funcione.
-
-1.  Ingrese a su consola de MySQL:
+1.  Clonar el repositorio.
+2. Crear el archivo de variables de entorno ```.env``` basado en la plantilla:
     ```bash
-    sudo mysql
+    cp env.sample .env
     ```
-
-2.  Ejecute los siguientes comandos SQL para preparar el entorno:
-    ```sql
-    -- Crear la base de datos
-    CREATE DATABASE lp3_db;
-
-    -- Crear el usuario (coincide con application.properties)
-    CREATE USER 'alumno'@'localhost' IDENTIFIED BY 'secreto';
-
-    -- Dar permisos totales
-    GRANT ALL PRIVILEGES ON lp3_db.* TO 'alumno'@'localhost';
-    FLUSH PRIVILEGES;
-    EXIT;
-    ```
+   (El archivo ```.env``` ya viene configurado con credenciales por defecto funcionales).
 
 ## Ejecución
 
-1.  Clonar este repositorio.
-2.  Abrir el proyecto en **IntelliJ IDEA** (o su IDE de preferencia).
-3.  Permitir que Maven descargue las dependencias (Drivers, Spring, etc.).
-4.  Ejecutar la clase principal: `src/main/java/py/edu/uc/lp3/Application.java`.
-
-La aplicación iniciará en el puerto **8080**.
-Las tablas (`persona`, `empresa`, etc.) se crearán automáticamente al iniciar.
-
-## Pruebas de la API (Testing)
-
-Para verificar que la aplicación guarda y recupera datos correctamente de MySQL, puede utilizar `curl` desde la terminal.
-
-### 1. Insertar una Persona (POST)
-```bash
-# Nota: La barra final '/' es requerida por la configuración del controlador
-curl -X POST http://localhost:8080/api/lp3/persona/ \
-  -H 'Content-Type: application/json' \
-  -d '{"nombre": "Test", "apellido": "User", "edad": 30, "numeroCedula": 12345, "sexo": "M"}'
-```
-### 2. Listar Personas (GET)
-```bash
-curl -s http://localhost:8080/api/lp3/persona/ | jq
-# (Se recomienda tener instalado jq para visualizar mejor la respuesta JSON: sudo apt install jq)
-```
-
-## Ejecución con Docker Compose
-
-Este proyecto incluye configuración para ejecutarse en contenedores Docker, orquestando la aplicación y la base de datos automáticamente.
-
-### Requisitos
-
-* Docker y Docker Compose instalados.
-
-### Paso a Paso
-
-1. **Configurar credenciales:**
-Crear un archivo ```.env``` en la raíz del proyecto tomando como base el ejemplo:
-```bash
-cp env.sample .env
-```
-
-(El archivo .env ya está configurado con credenciales por defecto funcionales).
-
-2. **Iniciar la aplicación:**
-Ejecutar el siguiente comando para construir y levantar los servicios:
+Para descargar dependencias, compilar el código, levantar la base de datos e iniciar la aplicación, ejecute un solo comando:
 ```bash
 docker compose up --build
 ```
 
-3. **Acceso:**
+* **API Spring Boot:** Disponible en el puerto **8081**.
+* **MySQL:** Disponible en el puerto **3307**.
 
-* **API Spring Boot:** Disponible en ```http://localhost:8081/api/lp3/persona/``` (Note el puerto 8081).
+## Pruebas (Testing)
 
-* **Base de Datos:** Accesible desde el host en el puerto **3307.**
+Una vez que la aplicación inicie (verifique que diga ```Started Application``` en la consola), puede probarla desde otra terminal:
 
-4. **Detener:**
-Para apagar los contenedores:
+### 1. Insertar una Persona (POST)
+```bash
+curl -X POST http://localhost:8081/api/lp3/persona/ \
+  -H 'Content-Type: application/json' \
+  -d '{"nombre": "Docker", "apellido": "User", "edad": 20, "numeroCedula": 123, "sexo": "M"}'
+```
+### 2. Listar Personas (GET)
+```bash
+curl -s http://localhost:8081/api/lp3/persona/ | jq
+```
+## Detener
+
+Para apagar y limpiar los contenedores:
 ```bash
 docker compose down
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.8'
+
+services:
+  # SERVICIO 1: Base de Datos MySQL
+  db:
+    image: mysql:8.0
+    container_name: springboot_mysql_lp3
+    restart: always
+    # Carga las variables desde el archivo .env
+    env_file:
+      - .env
+    # Mapeo de variables del .env a las que espera MySQL
+    environment:
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+    # PUERTO: 3307 en tu PC -> 3306 en el contenedor
+    ports:
+      - "3307:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    # Chequeo de salud: Avisa cuando la base de datos esté lista para recibir conexiones
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+
+  # SERVICIO 2: Tu Aplicación Spring Boot
+  app:
+    build: .
+    container_name: springboot_app_lp3
+    restart: on-failure
+    # PUERTO: 8081 en tu PC -> 8080 en el contenedor
+    ports:
+      - "8081:8080"
+    # Esperar a que la base de datos esté saludable antes de iniciar
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      # Sobrescribimos la conexión para usar el contenedor 'db' en lugar de localhost
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/${DB_NAME}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_USERNAME: ${DB_USER}
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+      # Configuraciones extra
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT: org.hibernate.dialect.MySQL8Dialect
+
+volumes:
+  mysql_data:

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,7 @@
+# --- PLANTILLA DE CONFIGURACIÓN ---
+# Copia este archivo a un archivo llamado '.env' y completa con tus datos.
+
+DB_NAME=lp3_db
+DB_USER=proyecto_user
+DB_PASSWORD=TU_CONTRASEÑA_AQUI
+DB_ROOT_PASSWORD=TU_ROOT_PASSWORD_AQUI

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,8 @@
-# --- CONFIGURACIÓN MYSQL (NUEVA) ---
-
-# Conexión a tu base de datos 'lp3_db' en el puerto 3306
 spring.datasource.url=jdbc:mysql://localhost:3306/lp3_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-
-# Tus credenciales (las que creamos en la terminal)
 spring.datasource.username=alumno
 spring.datasource.password=secreto
-
-# El Driver oficial de MySQL
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# --- HIBERNATE (Para que cree las tablas sola) ---
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## Resumen
Este PR implementa la solución para el **Issue #1**, agregando la orquestación completa del proyecto mediante Docker y Docker Compose.

Se ha configurado el entorno para levantar tanto la aplicación Spring Boot como la base de datos MySQL con un solo comando, sin necesidad de instalar dependencias locales (Java/Maven/MySQL).

## Cambios Implementados
- **Dockerfile:** Se creó un archivo `Dockerfile` multi-stage para compilar y empaquetar la aplicación de forma autónoma.
- **Docker Compose:** Se creó `docker-compose.yml` para orquestar los servicios `app` y `db`.
- **Configuración de Red y Puertos:**
  - App Spring Boot accesible en el puerto **8081**.
  - Base de Datos MySQL accesible en el puerto **3307**.
- **Seguridad:** Se implementó el uso de variables de entorno (`.env`) y se agregó `env.sample` como plantilla.
- **Documentación:** Se actualizó el `README.md` con instrucciones paso a paso para la ejecución con Docker.

## Cómo Probar
1. Clonar la rama.
2. Crear el archivo de variables: `cp env.sample .env`.
3. Ejecutar el entorno:
   ```bash
   docker compose up --build
4. Acceder a la API en: http://localhost:8081/api/lp3/persona/
## Notas Adicionales
El archivo .env ha sido agregado al .gitignore para evitar exponer credenciales sensibles.